### PR TITLE
Exclude specific speakers from showing in module

### DIFF
--- a/sonos.js
+++ b/sonos.js
@@ -13,7 +13,8 @@
 		updateInterval: 0.5, // every 0.5 minutes
 		apiBase: 'http://localhost',
 		apiPort: 5005,
-		apiEndpoint: 'zones'
+		apiEndpoint: 'zones',
+		exclude: []
 	},
 	start: function() {
 		Log.info('Starting module: ' + this.name);
@@ -29,23 +30,30 @@
 			this.config.apiBase + ":" + this.config.apiPort + "/" + this.config.apiEndpoint);
 	},
 	render: function(data){
+	console.log(data)
 		var text = '';
-		$.each(data, function (i, item) {
-			var room = item.coordinator.roomName;
-			var state = item.coordinator.state.zoneState;
-			var artist = item.coordinator.state.currentTrack.artist;
-			var track = item.coordinator.state.currentTrack.title;
-			var cover = item.coordinator.state.currentTrack.absoluteAlbumArtURI;
-			var streamInfo = item.coordinator.state.currentTrack.streamInfo;
-			if(item.members.length > 1){
-				room = '';
-				$.each(item.members, function (j, member) {
-					room += member.roomName + ', ';
-				});
-				room = room.slice(0, -2);
+		$.each(data, (i, item) => {
+			if(this.config.exclude.indexOf(item.coordinator.roomName) === -1 || item.members.length > 1){
+				var room = item.coordinator.roomName;
+				var state = item.coordinator.state.zoneState;
+				var artist = item.coordinator.state.currentTrack.artist;
+				var track = item.coordinator.state.currentTrack.title;
+				var cover = item.coordinator.state.currentTrack.absoluteAlbumArtURI;
+				var streamInfo = item.coordinator.state.currentTrack.streamInfo;
+				if(item.members.length > 1){
+					room = '';
+					$.each(item.members, (j, member) => {
+						if(this.config.exclude.indexOf(member.roomName) === -1){
+							room += member.roomName + ', ';
+						}
+					});
+					room = room.replace(/, $/,"");
+				}
+				if(room !== ''){
+					text += this.renderRoom(state, artist, track, cover, room);
+				}
 			}
-			text += this.renderRoom(state, artist, track, cover, room);
-		}.bind(this));
+		});
 		this.loaded = true;
 		// only update dom if content changed
 		if(this.dom !== text){


### PR DESCRIPTION
If you want to exclude specific speakers from showing in module, add config option exclude into the magic mirror config.js file

eg.  exclude: ['speaker name 1','Speaker name 2','Speaker name 3'],